### PR TITLE
Implement (de)activate action to a promotion

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -140,6 +140,49 @@ def list_promotions():
     return make_response(jsonify(results), status.HTTP_200_OK)
 
 ######################################################################
+# Activate PROMOTIONS
+######################################################################
+
+
+@app.route("/promotions/<int:promotion_id>/activate", methods=["PUT"])
+def activate_promotions(promotion_id):
+    """Activate one Promotion by Promotion ID"""
+    app.logger.info("Request to activate promotion with id: %s", promotion_id)
+
+    promotion = Promotion.find(promotion_id)
+    if not promotion:
+        abort(status.HTTP_404_NOT_FOUND,
+              f"Promotion with id '{promotion_id}' was not found.")
+
+    promotion.available = True
+    promotion.update()
+
+    app.logger.info("Promotion with ID [%s] updated.", promotion.id)
+    return jsonify(promotion.serialize()), status.HTTP_200_OK
+
+######################################################################
+# Deactivate PROMOTIONS
+######################################################################
+
+
+@app.route("/promotions/<int:promotion_id>/deactivate", methods=["PUT"])
+def deactivate_promotions(promotion_id):
+    """Deactivate one Promotion by Promotion ID"""
+    app.logger.info(
+        "Request to deactivate promotion with id: %s", promotion_id)
+
+    promotion = Promotion.find(promotion_id)
+    if not promotion:
+        abort(status.HTTP_404_NOT_FOUND,
+              f"Promotion with id '{promotion_id}' was not found.")
+
+    promotion.available = False
+    promotion.update()
+
+    app.logger.info("Promotion with ID [%s] updated.", promotion.id)
+    return jsonify(promotion.serialize()), status.HTTP_200_OK
+
+######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
 

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,9 +1,7 @@
 """
 Test Error Handlers Test Suite
 """
-import logging
 from unittest import TestCase
-from service.common import error_handlers
 
 ######################################################################
 #  T E S T   C A S E S

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -198,3 +198,51 @@ class TestPromotionService(TestCase):
         logging.debug(new_promotion)
         response = self.client.put(f"{BASE_URL}/1", json=new_promotion)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_activate_promotions(self):
+        '''This should test activating promotions using non-CRUD route'''
+        test_promotion = PromotionFactory()
+        test_promotion.available = False
+        logging.debug(test_promotion)
+
+        response = self.client.post(BASE_URL, json=test_promotion.serialize())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        new_promotion = response.get_json()
+
+        response = self.client.put(
+            f"{BASE_URL}/{new_promotion['id']}/activate")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        updated_promotion = response.get_json()
+
+        self.assertEqual(updated_promotion["available"], True)
+
+        # testing activating a non existent promotion
+        response = self.client.put(f"{BASE_URL}/0/activate")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_deactivate_promotions(self):
+        '''This should test deactivating promotions using non-CRUD route'''
+        test_promotion = PromotionFactory()
+        test_promotion.available = True
+        logging.debug(test_promotion)
+
+        response = self.client.post(BASE_URL, json=test_promotion.serialize())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        new_promotion = response.get_json()
+
+        response = self.client.put(
+            f"{BASE_URL}/{new_promotion['id']}/deactivate")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        updated_promotion = response.get_json()
+
+        self.assertEqual(updated_promotion["available"], False)
+
+        # testing deactivating a non existent promotion
+        response = self.client.put(f"{BASE_URL}/0/deactivate")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Implemented test-driven activate/deactivate action using PUT request.
The route is "/promotions/<promotion_id>/activate" or "/promotions/<promotion_id>/deactivate"